### PR TITLE
Add date type for PostgreSQL

### DIFF
--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -157,6 +157,13 @@ func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 			typ = "pq.NullTime"
 		}
 
+	case "date":
+		typ = "*time.Time"
+		if nullable {
+			nilVal = "pq.NullTime{}"
+			typ = "pq.NullTime"
+		}
+
 	case "time with time zone", "time without time zone", "timestamp without time zone":
 		nilVal = "0"
 		typ = "int64"


### PR DESCRIPTION
Hi, first of all thank you for opensourcing this great work, and I really like your approach.

One thing I realized when generating struct against my tables, xo doesn't seem like recognize `date` type of PostgreSQL. So, I added a case for `date`. If I'm missing something, please let me know, I'll update p-r.

Thanks!