### PR TITLE
fix MySQL bit type conversion to Go type

### DIFF
--- a/loaders/mysql.go
+++ b/loaders/mysql.go
@@ -79,8 +79,34 @@ func MyParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 	dt, precision, _ = args.ParsePrecision(dt)
 
 	var typ string
+
+switchDT:
 	switch dt {
-	case "bool", "boolean", "bit":
+	case "bit":
+		nilVal = "0"
+		if precision == 1 {
+			nilVal = "false"
+			typ = "bool"
+			if nullable {
+				nilVal = "sql.NullBool{}"
+				typ = "sql.NullBool"
+			}
+			break switchDT
+		} else if precision <= 8 {
+			typ = "uint8"
+		} else if precision <= 16 {
+			typ = "uint16"
+		} else if precision <= 32 {
+			typ = "uint32"
+		} else {
+			typ = "uint64"
+		}
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "bool", "boolean":
 		nilVal = "false"
 		typ = "bool"
 		if nullable {
@@ -103,6 +129,7 @@ func MyParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 			nilVal = "sql.NullInt64{}"
 			typ = "sql.NullInt64"
 		}
+
 	case "int", "integer":
 		nilVal = "0"
 		typ = args.Int32Type
@@ -110,6 +137,7 @@ func MyParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 			nilVal = "sql.NullInt64{}"
 			typ = "sql.NullInt64"
 		}
+
 	case "bigint":
 		nilVal = "0"
 		typ = "int64"
@@ -125,6 +153,7 @@ func MyParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 			nilVal = "sql.NullFloat64{}"
 			typ = "sql.NullFloat64"
 		}
+
 	case "decimal", "double":
 		nilVal = "0.0"
 		typ = "float64"

--- a/loaders/mysql_test.go
+++ b/loaders/mysql_test.go
@@ -1,0 +1,106 @@
+package loaders_test
+
+import (
+	"testing"
+
+	"github.com/knq/xo/internal"
+	"github.com/knq/xo/loaders"
+)
+
+func Test_MyParseType(t *testing.T) {
+	tests := []struct {
+		desc      string
+		dt        string
+		precision int
+		nilVal    string
+		typ       string
+		nullable  bool
+	}{
+		{
+			desc:      "bit(1) parses",
+			dt:        "bit(1)",
+			precision: 1,
+			nilVal:    "false",
+			typ:       "bool",
+		},
+		{
+			desc:      "bit(2) parses",
+			dt:        "bit(2)",
+			precision: 2,
+			nilVal:    "0",
+			typ:       "uint8",
+		},
+		{
+			desc:      "bit(8) parses",
+			dt:        "bit(8)",
+			precision: 8,
+			nilVal:    "0",
+			typ:       "uint8",
+		},
+		{
+			desc:      "bit(9) parses",
+			dt:        "bit(9)",
+			precision: 9,
+			nilVal:    "0",
+			typ:       "uint16",
+		},
+		{
+			desc:      "bit(16) parses",
+			dt:        "bit(16)",
+			precision: 16,
+			nilVal:    "0",
+			typ:       "uint16",
+		},
+		{
+			desc:      "bit(17) parses",
+			dt:        "bit(17)",
+			precision: 17,
+			nilVal:    "0",
+			typ:       "uint32",
+		},
+		{
+			desc:      "bit(32) parses",
+			dt:        "bit(32)",
+			precision: 32,
+			nilVal:    "0",
+			typ:       "uint32",
+		},
+		{
+			desc:      "bit(33) parses",
+			dt:        "bit(33)",
+			precision: 33,
+			nilVal:    "0",
+			typ:       "uint64",
+		},
+		{
+			desc:      "bit(64) parses",
+			dt:        "bit(64)",
+			precision: 64,
+			nilVal:    "0",
+			typ:       "uint64",
+		},
+		{
+			desc:      "nullable bit type with precision == 1 parses",
+			dt:        "bit(1)",
+			precision: 1,
+			nilVal:    "sql.NullBool{}",
+			typ:       "sql.NullBool",
+			nullable:  true,
+		},
+		{
+			desc:      "nullable bit type with precision > 1 parses",
+			dt:        "bit(64)",
+			precision: 64,
+			nilVal:    "sql.NullInt64{}",
+			typ:       "sql.NullInt64",
+			nullable:  true,
+		},
+	}
+
+	for i, tt := range tests {
+		precision, nilVal, typ := loaders.MyParseType(&internal.ArgType{}, tt.dt, tt.nullable)
+		if precision != tt.precision || nilVal != tt.nilVal || typ != tt.typ {
+			t.Fatalf("test #%d: %s\n\texp: %d, %s, %s\n\tgot: %d, %s, %s", i+1, tt.desc, tt.precision, tt.nilVal, tt.typ, precision, nilVal, typ)
+		}
+	}
+}


### PR DESCRIPTION
- Special case MySQL `bit(1)` to map to Go `bool`
- Other precisions of MySQL `bit` type map to `uint8`, `uint16`, `uint32`, or `uint64`
- Added test for `bit` type conversions

I also tested this against the following table in MySQL:
```
CREATE TABLE `dummy` (
  `iddummy` int(11) NOT NULL AUTO_INCREMENT,
  `dummycol` bit(1) NOT NULL,
  `dummycol2` bit(8) NOT NULL,
  `dummycol3` bit(9) NOT NULL,
  `dummycol5` bit(16) NOT NULL,
  `dummycol1` bit(17) NOT NULL,
  `dummycol4` bit(32) NOT NULL,
  `dummycol6` bit(33) NOT NULL,
  `dummycol7` bit(64) NOT NULL,
  `dummycol8` bit(64) DEFAULT NULL,
  `dummycol9` bit(1) DEFAULT NULL,
  PRIMARY KEY (`iddummy`)
) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
```
One possible issue is that if a type is nullable, it maps to `sql.NullInt64`, so the high bit is not usable.