### PR TITLE
Add support for ignoring fields

### DIFF
--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -40,6 +40,9 @@ type ArgType struct {
 	// Uint32Type is the type to assign those discovered as uint32.
 	Uint32Type string `arg:"--uint32-type,-u,help:Go type to assign to unsigned integers"`
 
+	// IgnoreFields allows the user to specify field names which should not be handled by xo in the generated code.
+	IgnoreFields []string `arg:"--ignore-fields,help:Fields to exclude from the generated code"`
+
 	// IncTypes are the types to include.
 	InclTypes []string `arg:"--include,help:include type(s)"`
 

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -496,6 +496,24 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 
 	// process columns
 	for _, c := range columnList {
+		ignore := false
+
+		for _, ignoreField := range args.IgnoreFields {
+			if ignoreField == c.ColumnName {
+				// Skip adding this field if user has specified they are not
+				// interested.
+				//
+				// This could be useful for fields which are managed by the
+				// database (e.g. automatically updated timestamps) instead of
+				// via Go code.
+				ignore = true
+			}
+		}
+
+		if ignore {
+			continue
+		}
+
 		// set col info
 		f := &Field{
 			Name: SnakeToIdentifier(c.ColumnName),


### PR DESCRIPTION
cc @knq

Let me know what you think -- this should be useful for supporting DB-managed fields.

I thought about using labeled breaks but just having an `ignore` value seems a smidge cleaner to me.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>