### PR TITLE
Mark SQLite primary key indexes

### DIFF
--- a/loaders/sqlite.go
+++ b/loaders/sqlite.go
@@ -26,7 +26,16 @@ func init() {
 			return models.SqTableForeignKeys(db, table)
 		},
 		IndexList: func(db models.XODB, schema string, table string) ([]*models.Index, error) {
-			return models.SqTableIndexes(db, table)
+			indexes, err := models.SqTableIndexes(db, table)
+			if err != nil {
+				return nil, err
+			}
+			for _, index := range indexes {
+				if index.Origin == "pk" {
+					index.IsPrimary = true
+				}
+			}
+			return indexes, nil
 		},
 		IndexColumnList: func(db models.XODB, schema string, table string, index string) ([]*models.IndexColumn, error) {
 			return models.SqIndexColumns(db, index)


### PR DESCRIPTION
`xo` was creating multiple (conflicting) definitions of FindByName, where `name` was the table's primary key.  One was generated by `settings_name_pkey`; the other `sqlite_autoindex_settings_1`.

Here's the (tiny) schema this PR was tested with:
```
SQLite version 3.8.10.2 2015-05-20 18:17:19
Enter ".help" for usage hints.
sqlite> .headers on
sqlite> .fullschema
CREATE TABLE migration_version (
			version INTEGER
		);
CREATE TABLE settings (
  name TEXT NOT NULL PRIMARY KEY,
  value TEXT NOT NULL
);
CREATE INDEX settings_by_value ON settings (value)
;
/* No STAT tables available */
sqlite> PRAGMA index_list(settings);
seq|name|unique|origin|partial
0|settings_by_value|0|c|0
1|sqlite_autoindex_settings_1|1|pk|0
sqlite> 
```

Thanks for releasing this tool!  Excited about building something with it.