### PR TITLE
Add `hascolumn()` template function

### DIFF
--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -26,6 +26,7 @@ func (a *ArgType) NewTemplateFuncs() template.FuncMap {
 		"convext":        a.convext,
 		"schema":         a.schemafn,
 		"colname":        a.colname,
+		"hascolumn":      a.hascolumn,
 	}
 }
 
@@ -444,4 +445,14 @@ func (a *ArgType) colname(col *models.Column) string {
 	}
 
 	return col.ColumnName
+}
+
+// hascolumn returns by bool if .Fields has "colName" or not.
+func (a *ArgType) hascolumn(fields []*Field, colName string) bool {
+	for _, f := range fields {
+		if a.colname(f.Col) == colName {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
I added a template function named `hascolumn()`.

For example, if you want to update only the `updated_at` column
if the table has `updated_at` column.

```
// templates/mysql.type.go.tpl

/ Update updates the {{ .Name }} in the database.
func ({{ $short }} *{{ .Name }}) Update(db XODB) error {
	...

  {{ if hascolumn .Fields "updated_at" }}

  {{$short}}.UpdatedAt = time.Now().Unix()

  {{ end }}

  ...
}
```