### PR TITLE
Add replace (strings.Replace) template function

### DIFF
--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -26,6 +26,7 @@ func (a *ArgType) NewTemplateFuncs() template.FuncMap {
 		"convext":        a.convext,
 		"schema":         a.schemafn,
 		"colname":        a.colname,
+		"replace":        strings.Replace,
 	}
 }
 


### PR DESCRIPTION
There is a situation that you need to change a template in a way that (db XODB{{ goparamlist .Fields true }}) to be ({{ goparamlist .Fields true }}) but since the goparamlist by default prefix a comma when it returns and there is no other way to ignore that except having a replace function and keeping goparamlist unchanged ex. ({{ (replace (goparamlist .Fields true) ,  1) }})