### PR TITLE
Fields with multiple constraints are duplicated in structs

### DIFF
--- a/models/column.xo.go
+++ b/models/column.xo.go
@@ -30,7 +30,7 @@ func PgTableColumns(db XODB, schema string, table string, sys bool) ([]*Column, 
 		`FROM pg_attribute a ` +
 		`JOIN ONLY pg_class c ON c.oid = a.attrelid ` +
 		`JOIN ONLY pg_namespace n ON n.oid = c.relnamespace ` +
-		`LEFT JOIN pg_constraint ct ON ct.conrelid = c.oid AND a.attnum = ANY(ct.conkey) AND ct.contype IN('p', 'u') ` +
+		`LEFT JOIN pg_constraint ct ON ct.conrelid = c.oid AND a.attnum = ANY(ct.conkey) AND ct.contype = 'p' ` +
 		`LEFT JOIN pg_attrdef ad ON ad.adrelid = c.oid AND ad.adnum = a.attnum ` +
 		`WHERE a.attisdropped = false AND n.nspname = $1 AND c.relname = $2 AND ($3 OR a.attnum > 0) ` +
 		`ORDER BY a.attnum`


### PR DESCRIPTION
Fixed an issue where we were getting duplicate fields for a table if a field
had multiple constraints on it. Since this query returns 'true' only when the
field is a primary key, and the output doesn't appear to differ if there are other
indexes, limiting the left join to only primary key constraints fixed my issue
with duplicate fields.