### PR TITLE
Add uuid type for postgres

### DIFF
--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -179,6 +179,10 @@ func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 	case "hstore":
 		typ = "hstore.Hstore"
 
+	case "uuid":
++               nilVal = "uuid.New()"
++               typ = "uuid.UUID"
+		
 	default:
 		if strings.HasPrefix(dt, args.Schema+".") {
 			// in the same schema, so chop off


### PR DESCRIPTION
While pgcrypto doesn't yet work with xo (see https://github.com/knq/xo/issues/74), it is possible to get the "uuid-ossp" extension working. After adding this type loader I was able to successfully use xo to generate and compile code that handles uuid columns correctly.