### PR TITLE
sqlite3 - Detect INTEGER PRIMARY KEY as not manualpk

### DIFF
--- a/loaders/sqlite.go
+++ b/loaders/sqlite.go
@@ -143,6 +143,20 @@ func SqTables(db models.XODB, schema string, relkind string) ([]*models.Table, e
 			lSQL := strings.ToLower(autoInc.SQL)
 			if autoInc.TableName == row.TableName && strings.Contains(lSQL, "autoincrement") {
 				manualPk = false
+			} else {
+				cols, err := SqTableColumns(db, schema, row.TableName)
+				if err != nil {
+					return nil, err
+				}
+				var col *models.Column
+				for _, col = range cols {
+					if col.IsPrimaryKey == true {
+						if col.DataType == "integer" {
+							manualPk = false
+						}
+						break
+					}
+				}
 			}
 		}
 		tables = append(tables, &models.Table{


### PR DESCRIPTION
close #85
I can't say I am exactly fond of this method (table info will be queried up to 2x per table) but it should suffice.  Considering I don't feel performance (during generation) that significant for this case.  I wanted to accomplish this with as little change as possible.

**note:** this change will cause previously generated code (for sqlite3) to be different.