### PR TITLE
Escape names in MySQL using backtick.

### DIFF
--- a/loaders/mysql.go
+++ b/loaders/mysql.go
@@ -27,6 +27,11 @@ func init() {
 		IndexList:       models.MyTableIndexes,
 		IndexColumnList: models.MyIndexColumns,
 		QueryColumnList: MyQueryColumns,
+		Esc: map[internal.EscType]func(string) string{
+			internal.ColumnEsc: MyEscape,
+			internal.TableEsc:  MyEscape,
+			internal.SchemaEsc: MyEscape,
+		},
 	}
 }
 
@@ -277,4 +282,10 @@ func MyQueryColumns(args *internal.ArgType, inspect []string) ([]*models.Column,
 
 	// load column information
 	return cols, err
+}
+
+// MyEscape escapes names using the backtick (`).
+// https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
+func MyEscape(s string) string {
+	return "`" + s + "`"
 }

--- a/loaders/mysql_test.go
+++ b/loaders/mysql_test.go
@@ -104,3 +104,32 @@ func Test_MyParseType(t *testing.T) {
 		}
 	}
 }
+
+func Test_MyEscape(t *testing.T) {
+	l := internal.SchemaLoaders["mysql"]
+	name := "Name"
+	expectedEscape := "`Name`"
+	tests := []struct {
+		desc    string
+		escType internal.EscType
+	}{
+		{
+			desc:    "SchemaEsc",
+			escType: internal.SchemaEsc,
+		},
+		{
+			desc:    "TableEsc",
+			escType: internal.TableEsc,
+		},
+		{
+			desc:    "ColumnEsc",
+			escType: internal.ColumnEsc,
+		},
+	}
+	for i, tt := range tests {
+		esc := l.Escape(tt.escType, name)
+		if esc != expectedEscape {
+			t.Errorf("test #%d: Escape for %v failed. exp: %v got: %v", i, tt.desc, expectedEscape, esc)
+		}
+	}
+}

--- a/templates/mysql.index.go.tpl
+++ b/templates/mysql.index.go.tpl
@@ -1,1 +1,58 @@
-postgres.index.go.tpl
+{{- $short := (shortname .Type.Name "err" "sqlstr" "db" "q" "res" "XOLog" .Fields) -}}
+{{- $table := (schema .Schema .Type.Table.TableName) -}}
+// {{ .FuncName }} retrieves a row from '{{ $table }}' as a {{ .Type.Name }}.
+//
+// Generated from index '{{ .Index.IndexName }}'.
+func {{ .FuncName }}(db XODB{{ goparamlist .Fields true true }}) ({{ if not .Index.IsUnique }}[]{{ end }}*{{ .Type.Name }}, error) {
+	var err error
+
+	// sql query
+	const sqlstr = "SELECT " +
+		"{{ colnames .Type.Fields }} " +
+		"FROM {{ $table }} " +
+		"WHERE {{ colnamesquery .Fields " AND " }}"
+
+	// run query
+	XOLog(sqlstr{{ goparamlist .Fields true false }})
+{{- if .Index.IsUnique }}
+	{{ $short }} := {{ .Type.Name }}{
+	{{- if .Type.PrimaryKey }}
+		_exists: true,
+	{{ end -}}
+	}
+
+	err = db.QueryRow(sqlstr{{ goparamlist .Fields true false }}).Scan({{ fieldnames .Type.Fields (print "&" $short) }})
+	if err != nil {
+		return nil, err
+	}
+
+	return &{{ $short }}, nil
+{{- else }}
+	q, err := db.Query(sqlstr{{ goparamlist .Fields true false }})
+	if err != nil {
+		return nil, err
+	}
+	defer q.Close()
+
+	// load results
+	res := []*{{ .Type.Name }}{}
+	for q.Next() {
+		{{ $short }} := {{ .Type.Name }}{
+		{{- if .Type.PrimaryKey }}
+			_exists: true,
+		{{ end -}}
+		}
+
+		// scan
+		err = q.Scan({{ fieldnames .Type.Fields (print "&" $short) }})
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, &{{ $short }})
+	}
+
+	return res, nil
+{{- end }}
+}
+

--- a/templates/mysql.proc.go.tpl
+++ b/templates/mysql.proc.go.tpl
@@ -1,1 +1,28 @@
-postgres.proc.go.tpl
+{{- $notVoid := (ne .Proc.ReturnType "void") -}}
+{{- $proc := (schema .Schema .Proc.ProcName) -}}
+{{- if ne .Proc.ReturnType "trigger" -}}
+// {{ .Name }} calls the stored procedure '{{ $proc }}({{ .ProcParams }}) {{ .Proc.ReturnType }}' on db.
+func {{ .Name }}(db XODB{{ goparamlist .Params true true }}) ({{ if $notVoid }}{{ retype .Return.Type }}, {{ end }}error) {
+	var err error
+
+	// sql query
+	const sqlstr = "SELECT {{ $proc }}({{ colvals .Params }})"
+
+	// run query
+{{- if $notVoid }}
+	var ret {{ retype .Return.Type }}
+	XOLog(sqlstr{{ goparamlist .Params true false }})
+	err = db.QueryRow(sqlstr{{ goparamlist .Params true false }}).Scan(&ret)
+	if err != nil {
+		return {{ reniltype .Return.NilType }}, err
+	}
+
+	return ret, nil
+{{- else }}
+	XOLog(sqlstr)
+	_, err = db.Exec(sqlstr)
+	return err
+{{- end }}
+}
+{{- end }}
+

--- a/templates/mysql.query.go.tpl
+++ b/templates/mysql.query.go.tpl
@@ -1,1 +1,49 @@
-postgres.query.go.tpl
+{{- $short := (shortname .Type.Name "err" "sqlstr" "db" "q" "res" "XOLog" .QueryParams) -}}
+{{- $queryComments := .QueryComments -}}
+{{- if .Comment -}}
+// {{ .Comment }}
+{{- else -}}
+// {{ .Name }} runs a custom query, returning results as {{ .Type.Name }}.
+{{- end }}
+func {{ .Name }} (db XODB{{ range .QueryParams }}, {{ .Name }} {{ .Type }}{{ end }}) ({{ if not .OnlyOne }}[]{{ end }}*{{ .Type.Name }}, error) {
+	var err error
+
+	// sql query
+	{{ if .Interpolate }}var{{ else }}const{{ end }} sqlstr = {{ range $i, $l := .Query }}{{ if $i }} +{{ end }}{{ if (index $queryComments $i) }} // {{ index $queryComments $i }}{{ end }}{{ if $i }}
+	{{end -}}"{{ $l }}"{{ end }}
+
+	// run query
+	XOLog(sqlstr{{ range .QueryParams }}{{ if not .Interpolate }}, {{ .Name }}{{ end }}{{ end }})
+{{- if .OnlyOne }}
+	var {{ $short }} {{ .Type.Name }}
+	err = db.QueryRow(sqlstr{{ range .QueryParams }}, {{ .Name }}{{ end }}).Scan({{ fieldnames .Type.Fields (print "&" $short) }})
+	if err != nil {
+		return nil, err
+	}
+
+	return &{{ $short }}, nil
+{{- else }}
+	q, err := db.Query(sqlstr{{ range .QueryParams }}, {{ .Name }}{{ end }})
+	if err != nil {
+		return nil, err
+	}
+	defer q.Close()
+
+	// load results
+	res := []*{{ .Type.Name }}{}
+	for q.Next() {
+		{{ $short }} := {{ .Type.Name }}{}
+
+		// scan
+		err = q.Scan({{ fieldnames .Type.Fields (print "&" $short) }})
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, &{{ $short }})
+	}
+
+	return res, nil
+{{- end }}
+}
+

--- a/templates/mysql.type.go.tpl
+++ b/templates/mysql.type.go.tpl
@@ -39,11 +39,11 @@ func ({{ $short }} *{{ .Name }}) Insert(db XODB) error {
 
 {{ if .Table.ManualPk  }}
 	// sql insert query, primary key must be provided
-	const sqlstr = `INSERT INTO {{ $table }} (` +
-		`{{ colnames .Fields }}` +
-		`) VALUES (` +
-		`{{ colvals .Fields }}` +
-		`)`
+	const sqlstr = "INSERT INTO {{ $table }} (" +
+		"{{ colnames .Fields }}" +
+		") VALUES (" +
+		"{{ colvals .Fields }}" +
+		")"
 
 	// run query
 	XOLog(sqlstr, {{ fieldnames .Fields $short }})
@@ -56,11 +56,11 @@ func ({{ $short }} *{{ .Name }}) Insert(db XODB) error {
 	{{ $short }}._exists = true
 {{ else }}
 	// sql insert query, primary key provided by autoincrement
-	const sqlstr = `INSERT INTO {{ $table }} (` +
-		`{{ colnames .Fields .PrimaryKey.Name }}` +
-		`) VALUES (` +
-		`{{ colvals .Fields .PrimaryKey.Name }}` +
-		`)`
+	const sqlstr = "INSERT INTO {{ $table }} (" +
+		"{{ colnames .Fields .PrimaryKey.Name }}" +
+		") VALUES (" +
+		"{{ colvals .Fields .PrimaryKey.Name }}" +
+		")"
 
 	// run query
 	XOLog(sqlstr, {{ fieldnames .Fields $short .PrimaryKey.Name }})
@@ -98,9 +98,9 @@ func ({{ $short }} *{{ .Name }}) Update(db XODB) error {
 	}
 
 	// sql query
-	const sqlstr = `UPDATE {{ $table }} SET ` +
-		`{{ colnamesquery .Fields ", " .PrimaryKey.Name }}` +
-		` WHERE {{ colname .PrimaryKey.Col }} = ?`
+	const sqlstr = "UPDATE {{ $table }} SET " +
+		"{{ colnamesquery .Fields ", " .PrimaryKey.Name }}" +
+		" WHERE {{ colname .PrimaryKey.Col }} = ?"
 
 	// run query
 	XOLog(sqlstr, {{ fieldnames .Fields $short .PrimaryKey.Name }}, {{ $short }}.{{ .PrimaryKey.Name }})
@@ -132,7 +132,7 @@ func ({{ $short }} *{{ .Name }}) Delete(db XODB) error {
 	}
 
 	// sql query
-	const sqlstr = `DELETE FROM {{ $table }} WHERE {{ colname .PrimaryKey.Col }} = ?`
+	const sqlstr = "DELETE FROM {{ $table }} WHERE {{ colname .PrimaryKey.Col }} = ?"
 
 	// run query
 	XOLog(sqlstr, {{ $short }}.{{ .PrimaryKey.Name }})


### PR DESCRIPTION
The default identifier quote character for MySQL is the backtick (`)
https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
instead of the double quote (") used in Postgres
https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html

Add a MyEscape function that uses backticks, tests and update the
mysql template files to use double quotes for strings instead of
backticks.