### PR TITLE
Change mapping of MySQL time type to Go string type.

### DIFF
--- a/loaders/mysql.go
+++ b/loaders/mysql.go
@@ -184,13 +184,17 @@ switchDT:
 	case "binary", "varbinary", "tinyblob", "blob", "mediumblob", "longblob":
 		typ = "[]byte"
 
-	case "timestamp", "datetime", "date", "time":
+	case "timestamp", "datetime", "date":
 		nilVal = "time.Time{}"
 		typ = "time.Time"
 		if nullable {
 			nilVal = "mysql.NullTime{}"
 			typ = "mysql.NullTime"
 		}
+
+	case "time":
+		// time is not supported by the MySQL driver. Can parse the string to time.Time in the user code.
+		typ = "string"
 
 	default:
 		if strings.HasPrefix(dt, args.Schema+".") {


### PR DESCRIPTION
This addresses an issue raised in #67.  The MySQL time type is not supported for mapping in the MySQL Go driver to a time.Time object because it doesn't have a one-to-one relation with any type in Go (closest is a duration).  The best thing to do is to just map it as a string and that prevents an error in the query.  The consuming application can then map the type to a time in the user code by using the Time.Parse(layout, valuestring) feature.