### PR TITLE
Prepend table name to enum types

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -185,17 +185,17 @@ ENDSQL
 # mysql enum list query
 $XOBIN $MYDB -a -N -M -B -T Enum -F MyEnums -o $DEST $EXTRA << ENDSQL
 SELECT
-  DISTINCT column_name AS enum_name
+		DISTINCT CONCAT(table_name, "_", column_name) AS enum_name 
 FROM information_schema.columns
-WHERE data_type = 'enum' AND table_schema = %%schema string%%
+WHERE data_type = 'enum' AND table_schema =  %%schema string%%
 ENDSQL
 
 # mysql enum value list query
 $XOBIN $MYDB -N -M -B -1 -T MyEnumValue -F MyEnumValues -o $DEST $EXTRA << ENDSQL
-SELECT
-  SUBSTRING(column_type, 6, CHAR_LENGTH(column_type) - 6) AS enum_values
+SELECT 
+		SUBSTRING(column_type, 6, CHAR_LENGTH(column_type) - 6) AS enum_values
 FROM information_schema.columns
-WHERE data_type = 'enum' AND table_schema = %%schema string%% AND column_name = %%enum string%%
+WHERE data_type = 'enum' AND table_schema = %%schema string%% AND CONCAT(table_name, "_", column_name) = %%enum string%%
 ENDSQL
 
 # mysql autoincrement list query

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -489,6 +489,12 @@ func (tl TypeLoader) LoadRelkind(args *ArgType, relType RelType) (map[string]*Ty
 
 	// generate table templates
 	for _, t := range tableMap {
+		for _, field := range t.Fields {
+			if field.Col.ColumnName == field.Col.DataType {
+				//field is enum (or perhaps another special type)
+				field.Type = SingularizeIdentifier(t.Table.TableName + "_" + field.Type)
+			}
+		}
 		err = args.ExecuteTemplate(TypeTemplate, t.Name, "", t)
 		if err != nil {
 			return nil, err

--- a/loaders/mysql.go
+++ b/loaders/mysql.go
@@ -231,7 +231,7 @@ func MyEnumValues(db models.XODB, schema string, enum string) ([]*models.EnumVal
 	for i, ev := range strings.Split(res.EnumValues[1:len(res.EnumValues)-1], "','") {
 		enumVals = append(enumVals, &models.EnumValue{
 			EnumValue:  ev,
-			ConstValue: i + 1,
+			ConstValue: i,
 		})
 	}
 

--- a/models/enum.xo.go
+++ b/models/enum.xo.go
@@ -51,9 +51,9 @@ func MyEnums(db XODB, schema string) ([]*Enum, error) {
 
 	// sql query
 	const sqlstr = `SELECT ` +
-		`DISTINCT column_name AS enum_name ` +
+		`DISTINCT CONCAT(table_name, "_", column_name) AS enum_name ` +
 		`FROM information_schema.columns ` +
-		`WHERE data_type = 'enum' AND table_schema = ?`
+		`WHERE data_type = 'enum' AND table_schema =  ?`
 
 	// run query
 	XOLog(sqlstr, schema)

--- a/models/myenumvalue.xo.go
+++ b/models/myenumvalue.xo.go
@@ -16,7 +16,7 @@ func MyEnumValues(db XODB, schema string, enum string) (*MyEnumValue, error) {
 	const sqlstr = `SELECT ` +
 		`SUBSTRING(column_type, 6, CHAR_LENGTH(column_type) - 6) AS enum_values ` +
 		`FROM information_schema.columns ` +
-		`WHERE data_type = 'enum' AND table_schema = ? AND column_name = ?`
+		`WHERE data_type = 'enum' AND table_schema = ? AND CONCAT(table_name, "_", column_name) = ?`
 
 	// run query
 	XOLog(sqlstr, schema, enum)


### PR DESCRIPTION
Previously, generating on a db with multiple tables with the same enum name produced conflicting types.

I've tested the changes on a decently complex DB.

Also, I've changed the enum constant values to start at zero so the models' zero values can be worked with properly.

Fixes #57 