### PR TITLE
Add PrimaryKeyFields to types.Type allowing composite primary keys

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -535,13 +535,18 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 		}
 		f.Len, f.NilType, f.Type = tl.ParseType(args, c.DataType, !c.NotNull)
 
-		// set primary key
+		// Set primary key fields. Multiple columns may participate in a key.
 		if c.IsPrimaryKey && len(columnList) > 1 {
-			typeTpl.PrimaryKey = f
+			typeTpl.PrimaryKeyFields = append(typeTpl.PrimaryKeyFields, f)
 		}
 
 		// append col to template fields
 		typeTpl.Fields = append(typeTpl.Fields, f)
+	}
+
+	// set primary key if it is a single column
+	if len(typeTpl.PrimaryKeyFields) == 1 {
+		typeTpl.PrimaryKey = typeTpl.PrimaryKeyFields[0]
 	}
 
 	return nil

--- a/internal/types.go
+++ b/internal/types.go
@@ -119,13 +119,14 @@ type Field struct {
 
 // Type is a template item for a type (ie, table/view/custom query).
 type Type struct {
-	Name       string
-	Schema     string
-	RelType    RelType
-	PrimaryKey *Field
-	Fields     []*Field
-	Table      *models.Table
-	Comment    string
+	Name             string
+	Schema           string
+	RelType          RelType
+	PrimaryKey       *Field
+	PrimaryKeyFields []*Field
+	Fields           []*Field
+	Table            *models.Table
+	Comment          string
 }
 
 // ForeignKey is a template item for a foreign relationship on a table.

--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -65,6 +65,7 @@ func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 	if strings.HasSuffix(dt, "[]") {
 		dt = dt[:len(dt)-2]
 		asSlice = true
+		nullable = false
 	}
 
 	// extract precision

--- a/models/column.xo.go
+++ b/models/column.xo.go
@@ -32,7 +32,7 @@ func PgTableColumns(db XODB, schema string, table string, sys bool) ([]*Column, 
 		`FROM pg_attribute a ` +
 		`JOIN ONLY pg_class c ON c.oid = a.attrelid ` +
 		`JOIN ONLY pg_namespace n ON n.oid = c.relnamespace ` +
-		`LEFT JOIN pg_constraint ct ON ct.conrelid = c.oid AND a.attnum = ANY(ct.conkey) AND ct.contype IN('p', 'u') ` +
+		`LEFT JOIN pg_constraint ct ON ct.conrelid = c.oid AND a.attnum = ANY(ct.conkey) AND ct.contype = 'p' ` + // was IN('p', 'u')
 		`LEFT JOIN pg_attrdef ad ON ad.adrelid = c.oid AND ad.adnum = a.attnum ` +
 		`WHERE a.attisdropped = false AND n.nspname = $1 AND c.relname = $2 AND ($3 OR a.attnum > 0) ` +
 		`ORDER BY a.attnum`


### PR DESCRIPTION
Primary keys are not necessarily formed from a single column,
which is assumed by the templates. By adding a new attribute
PrimaryKeyFields that lists all of the fields that make up the
primary key, then it becomes possible to support composite primary
keys by using a custom template. The existing PrimaryKey attribute
is only set when the primary key is composed of a single column,
rather than containing an incorrect value that causes failures.

The existing templates have not yet been modified. If a table
has a composite primary key, code will be generated the same
as if it had no primary key defined rather than broken code
being generated.