### PR TITLE
Allow for primary key as the only column.

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -536,7 +536,7 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 		f.Len, f.NilType, f.Type = tl.ParseType(args, c.DataType, !c.NotNull)
 
 		// set primary key
-		if c.IsPrimaryKey && len(columnList) > 1 {
+		if c.IsPrimaryKey {
 			typeTpl.PrimaryKey = f
 		}
 


### PR DESCRIPTION
This simple change addresses issue #111 and is a low-risk change.  I found that the reason the problem was being hit is that in case of just a single primary key in the table with no other columns is that the loader.go was ignoring the PK because of the test for there being more than one column.  The previous fix addressed the case when there were also columns other than the PK but they were ignored so it didn't hit the test of just one column.

To test add the following table and verify that it generates code for the insert and delete functions but not the update/upsert.

```
CREATE TABLE subnetname (
  subnet_name text PRIMARY KEY
);
```




