### PR TITLE
Nil check for missing table.

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -609,6 +609,10 @@ func (tl TypeLoader) LoadTableForeignKeys(args *ArgType, tableMap map[string]*Ty
 			}
 		}
 
+		if refTpl == nil {
+			return fmt.Errorf("could not find table %q for fk %v in schema %v", fk.RefTableName, fk.ForeignKeyName, args.Schema)
+		}
+
 	refColLoop:
 		// find ref column
 		for _, f := range refTpl.Fields {


### PR DESCRIPTION
This 'fixes' #131 by preventing a panic when a foreign key references a
table in a different schema, though it does not actually enable parsing
of the separate schema.