### PR TITLE
Add null uuid support and change uuid backing lib

### DIFF
--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -181,8 +181,12 @@ func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 		typ = "hstore.Hstore"
 
 	case "uuid":
-		nilVal = "uuid.New()"
+		nilVal = "uuid.UUID{}"
 		typ = "uuid.UUID"
+		if nullable {
+			nilVal = "uuid.NullUUID{}"
+			typ = "uuid.NullUUID"
+		}
 
 	default:
 		if strings.HasPrefix(dt, args.Schema+".") {


### PR DESCRIPTION
My intentions: 
 - first is to avoid usage of function call in `nilVal` for non `nullable` case since we'd better to stick to structure instead of interface IMO;
 - and second is to add `NullUUID` structure for `nullable` case as its done for all other data types.

AFAIK there is only one [library](github.com/satori/go.uuid) now that has support for NullUUID, and it seems to be more mature and popular. In future, after google will release stable version of their own, I think we can use it or from `pq` if it will have smth, since `xo` already relies on some types from it.