### PR TITLE
Update postgres.type.go.tpl

### DIFF
--- a/templates/postgres.type.go.tpl
+++ b/templates/postgres.type.go.tpl
@@ -46,7 +46,7 @@ func ({{ $short }} *{{ .Name }}) Insert(db XODB) error {
 
 	// run query
 	XOLog(sqlstr, {{ fieldnames .Fields $short }})
-	err = db.QueryRow(sqlstr, {{ fieldnames .Fields $short }}).Scan(&{{ $short }}.{{ .PrimaryKey.Name }})
+	_, err = db.QueryRow(sqlstr, {{ fieldnames .Fields $short }})
 	if err != nil {
 		return err
 	}

--- a/templates/postgres.type.go.tpl
+++ b/templates/postgres.type.go.tpl
@@ -46,7 +46,7 @@ func ({{ $short }} *{{ .Name }}) Insert(db XODB) error {
 
 	// run query
 	XOLog(sqlstr, {{ fieldnames .Fields $short }})
-	_, err = db.QueryRow(sqlstr, {{ fieldnames .Fields $short }})
+	_, err = db.Exec(sqlstr, {{ fieldnames .Fields $short }})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
when there is no primary key returned, don't use `.Scan`