### PR TITLE
oracle: use precision and scale, to use it to decide type

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -429,7 +429,13 @@ $XOBIN $ORDB -a -N -M -B -T Column -F OrTableColumns -o $DEST $EXTRA << ENDSQL
 SELECT
   c.column_id AS field_ordinal,
   LOWER(c.column_name) AS column_name,
-  LOWER(c.data_type) AS data_type,
+  LOWER(CASE c.data_type
+          WHEN 'CHAR' THEN 'CHAR('||c.data_length||')'
+          WHEN 'VARCHAR2' THEN 'VARCHAR2('||data_length||')'
+          WHEN 'NUMBER' THEN
+		    (CASE WHEN c.data_precision IS NULL AND c.data_scale IS NULL THEN 'NUMBER'
+               ELSE 'NUMBER('||NVL(c.data_precision, 38)||','||NVL(c.data_scale, 0)||')' END)
+          ELSE c.data_type END) AS data_type,
   CASE WHEN c.nullable = 'N' THEN '1' ELSE '0' END AS not_null,
   COALESCE((SELECT CASE WHEN r.constraint_type = 'P' THEN '1' ELSE '0' END
     FROM all_cons_columns l, all_constraints r

--- a/models/column.xo.go
+++ b/models/column.xo.go
@@ -160,7 +160,12 @@ func OrTableColumns(db XODB, schema string, table string) ([]*Column, error) {
 	const sqlstr = `SELECT ` +
 		`c.column_id AS field_ordinal, ` +
 		`LOWER(c.column_name) AS column_name, ` +
-		`LOWER(c.data_type) AS data_type, ` +
+		`LOWER(CASE c.data_type
+           WHEN 'CHAR' THEN 'CHAR('||c.data_length||')'
+           WHEN 'VARCHAR2' THEN 'VARCHAR2('||data_length||')'
+           WHEN 'NUMBER' THEN (CASE WHEN c.data_precision IS NULL AND c.data_scale IS NULL THEN 'NUMBER'
+                               ELSE 'NUMBER('||NVL(c.data_precision, 38)||','||NVL(c.data_scale, 0)||')' END)
+	       ELSE c.data_type END) AS data_type, ` +
 		`CASE WHEN c.nullable = 'N' THEN '1' ELSE '0' END AS not_null, ` +
 		`COALESCE((SELECT CASE WHEN r.constraint_type = 'P' THEN '1' ELSE '0' END ` +
 		`FROM all_cons_columns l, all_constraints r ` +


### PR DESCRIPTION
Retrieve precision and scale in the type name,
and use it to decide between int64, flota64 and string for NUMBER.